### PR TITLE
Fix typo of `strip` in place of `unpack`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
         Command::Pack(v) => commands::archive::pack_files(&v)
             .expect("Failed to pack files"),
         Command::Unpack(v) => commands::archive::unpack_files(&v)
-            .expect("Failed to strip files"),
+            .expect("Failed to unpack files"),
         Command::Strip(v) => commands::strip::strip_files(&v)
             .expect("Failed to strip files")
     }


### PR DESCRIPTION
Self-explanatory. Unpack had the wrong error message.